### PR TITLE
Add NPM dependency installation step to DEVELOP.md.

### DIFF
--- a/Buddies.Web/src/pages/projects/[pid].tsx
+++ b/Buddies.Web/src/pages/projects/[pid].tsx
@@ -54,7 +54,6 @@ const Project: React.VFC = () => {
   }, [projectId]);
 
   const addMemberToProject = async () => {
-
     if (!(typeof projectId === 'string') || !authState) {
       alert('Uh oh, something went wrong...');
       return;

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -24,7 +24,8 @@ We recommend using **Visual Studio 2022** for the backend and **VS Code** for th
 3. Open `Buddies.sln` using Visual Studio.
 4. Use Debug > Start Debugging or Debug > Start Without Debugging to start the backend.
 5. Open the `Buddies.Web` folder using VS Code.
-6. Run `yarn dev` in the integrated terminal to start the frontend.
+6. Run `yarn` in the integrated terminal to install NPM dependencies.
+7. Run `yarn dev` to start the frontend.
 
 
 ### Migrations


### PR DESCRIPTION
Add a step to the development instructions related to installing NPM dependencies for the frontend project. There were occasions where members were confused about this step, used an outdated version of `npm` which resulted in errors & adding an extra `package-lock.json` to the repo, etc.